### PR TITLE
Fix: 'unmappable character for encoding ASCII'

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
 
     <target name="build" description="Compiling the Project LogFormatter">
         <mkdir dir ="${build.dir}"/>
-        <javac destdir="${build.dir}" source="1.7" target="1.7">
+        <javac destdir="${build.dir}" source="1.7" target="1.7" encoding="UTF8">
             <src path="${src.dir}"/>
         </javac>
         <jar destfile="${basedir}/MinecraftLogFormatter.jar"


### PR DESCRIPTION
i had the following issue:

```
[...]
    [javac] /.../MinecraftLogFormatter/LogFormatter.java:143: error: unmappable character for encoding ASCII
    [javac]         line = line.replace("??", "&szlig;");
    [javac]                               ^
    [javac] /.../MinecraftLogFormatter/LogFormatter.java:11: error: class, interface, or enum expected
    [javac] jc.getDefinition().set("encoding", "UTF8")
    [javac] ^
    [javac] 15 errors

BUILD FAILED
/.../MinecraftLogFormatter/build.xml:9: Compile failed; see the compiler error output for details.
```